### PR TITLE
fix: scroll layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -282,4 +282,9 @@ onUnmounted(() => {
 .layout > * + * {
   border-left: 1px solid var(--scalar-border-color);
 }
+
+
+.right {
+  overflow: auto;
+}
 </style>


### PR DESCRIPTION
this pr fixes layout issue on long editor content:

**before**
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/0af5bf5a-48f7-4208-937f-6f469f34c853">

**after**
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/fe953985-94ea-4197-895c-f93c0241bacf">
