### PR TITLE
fix(sandbox): sticky widget editor overflowing modal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -268,6 +268,7 @@ onUnmounted(() => {
   border-left: 1px solid var(--scalar-border-color);
 }
 
+.editor,
 .preview {
   overflow: auto;
   z-index: 0;


### PR DESCRIPTION
**Problem**
currently the sticky widget displayed on json usage is overflowing the client modal when scrolling and then opening it.

**Solution**
this pr sets z-index to the editor class.

| before | after |
| -------|------|
| <img width="826" alt="image" src="https://github.com/user-attachments/assets/c261152a-b375-4687-a66c-5257ec9c2079" /> | <img width="826" alt="image" src="https://github.com/user-attachments/assets/f2d0d94f-7080-4f00-92ec-728b817fd30d" /> |
| sticky widget overflowing client modal | client modal displayed as it should | 

**Checklist**

I’ve gone through the following:

- [x] I’ve added an explanation _why_ this change is needed.