### PR TITLE
fix(sandbox): initial renders with edit mode enabled regardless of path

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ const router = useRouter()
 
 const loading = ref<boolean>(false)
 
-const editing = ref<boolean>(true)
+const editing = ref<boolean>(route.name !== 'preview')
 
 const content = ref<string>(
   JSON.stringify(

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,4 +9,6 @@ const app = createApp(App)
 
 app.use(router)
 
-app.mount('#app')
+router.isReady().then(() => {
+  app.mount('#app')
+})


### PR DESCRIPTION
1. update initial state for editing ref to depend on route.name (editing vs preview)
2. delay mounting until router is ready so initial value of route can be captured by ref.


Related to https://github.com/scalar/scalar/issues/9658
