### PR TITLE
fix(sandbox): load spec on initial render for id links

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -152,6 +152,7 @@ watch(
         })
     }
   },
+  { immediate: true },
 )
 
 function handleDrop(text: string) {


### PR DESCRIPTION
## Problem

Opening a link with an id (e.g. `/e/:id`) showed the placeholder document instead of the spec.

## Cause

#524 added `router.isReady().then(() => app.mount())` in `main.ts`. Previously the app mounted *before* routing resolved, so `route.params.id` went `undefined → :id`, which triggered the content-fetch watcher. Now the router is ready before mount, so `route.params.id` is already set at setup time and the (non-immediate) watcher never fires — so the spec is never fetched.

## Fix

Add `{ immediate: true }` to the content-fetch watcher so it runs once on setup, loading the spec regardless of when the route resolves.

Tested locally: id links now load the correct document in edit mode.